### PR TITLE
Allow overriding host toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: CC0-1.0
 #
-# SPDX-FileContributor: Antonio Niño Díaz, 2023
+# SPDX-FileContributor: Antonio Niño Díaz, 2023-2024
+
+HOSTCC		?= gcc
 
 dldipatch: dldipatch.c
-	gcc -Wall -Wextra -Wno-unused-result -std=gnu11 -O3 -o $@ $<
+	$(HOSTCC) -Wall -Wextra -Wno-unused-result -std=gnu11 -O3 -o $@ $<
 
 .PHONY: clean
 


### PR DESCRIPTION
Also, in order to distinguish between ARM and host compiler, the toolchain-related variables have been renamed.