### PR TITLE
Fix system include path

### DIFF
--- a/dldipatch.c
+++ b/dldipatch.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <malloc.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
 


### PR DESCRIPTION
When I build this code in a GitHub actions pipeline I get this error:

    /usr/include/sys/fcntl.h:1:2: warning: #warning redirecting incorrect
    #include <sys/fcntl.h> to <fcntl.h> [-Wcpp]
        1 | #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h>
          |  ^~~