### PR TITLE
Improve build system and add "-V" command to print the version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,71 @@
 # SPDX-License-Identifier: CC0-1.0
 #
-# SPDX-FileContributor: Antonio Niño Díaz, 2023-2024
+# SPDX-FileContributor: Antonio Niño Díaz, 2023-2025
 
-HOSTCC		?= $(CC)
+# Tools
+# -----
+
+STRIP		:= -s
+BINMODE		:= 755
+
+HOSTCC		?= gcc
+CP		:= cp
+RM		:= rm -rf
+INSTALL		:= install
+
+# Version string handling
+# -----------------------
+
+# Try to generate a version string if it isn't already provided
+ifeq ($(VERSION_STRING),)
+    # Try an exact match with a tag (e.g. v1.12.1)
+    VERSION_STRING	:= $(shell git describe --tags --exact-match --dirty 2>/dev/null)
+    ifeq ($(VERSION_STRING),)
+        # Try a non-exact match (e.g. v1.12.1-3-g67a811a)
+        VERSION_STRING	:= $(shell git describe --tags --dirty 2>/dev/null)
+        ifeq ($(VERSION_STRING),)
+            # If no version is provided by the user or git, fall back to this
+            VERSION_STRING	:= DEV
+        endif
+    endif
+endif
+
+# Defines passed to all files
+# ---------------------------
+
+DEFINES		:= -DVERSION_STRING=\"$(VERSION_STRING)\"
+
+# Verbose flag
+# ------------
+
+ifeq ($(VERBOSE),1)
+V		:=
+else
+V		:= @
+endif
+
+# Targets
+# -------
+
+.PHONY: all clean install
+
+all: dldipatch
 
 dldipatch: dldipatch.c
-	$(HOSTCC) -Wall -Wextra -Wno-unused-result -std=gnu11 -O3 -o $@ $<
-
-.PHONY: clean
+	@echo "  HOSTCC  $<"
+	$(V)$(HOSTCC) $(DEFINES) -Wall -Wextra -Wno-unused-result -std=gnu11 -O3 -o $@ $<
 
 clean:
-	rm -rf dldipatch
+	@echo "  CLEAN  "
+	$(V)rm -rf dldipatch
+
+INSTALLDIR	?= /opt/blocksds/core/tools/dldipatch
+INSTALLDIR_ABS	:= $(abspath $(INSTALLDIR))
+
+install: all
+	@echo "  INSTALL $(INSTALLDIR_ABS)"
+	@test $(INSTALLDIR_ABS)
+	$(V)$(RM) $(INSTALLDIR_ABS)
+	$(V)$(INSTALL) -d $(INSTALLDIR_ABS)
+	$(V)$(INSTALL) $(STRIP) -m $(BINMODE) dldipatch $(INSTALLDIR_ABS)
+	$(V)$(CP) license.txt $(INSTALLDIR_ABS)

--- a/dldipatch.c
+++ b/dldipatch.c
@@ -354,10 +354,18 @@ void print_help(void)
 	printf("dldipatch extract homebrew dldi.dldi\n\n");
 	printf("Extracting a DLDI from a homebrew's embedded DLDI:\n");
 	printf("dldipatch info dldi/homebrew \n\n");
+	printf("Print version of dldipatch:\n");
+	printf("dldipatch -V\n\n");
 }
 
 int main(const int argc, const char **argv)
 {
+	if ((argc == 2) && (strcmp(argv[1], "-V") == 0))
+	{
+		printf("dldipatch " VERSION_STRING "\n");
+		return 0;
+	}
+
 	if (argc < 2 || (argc < 4 && strncmp(argv[1], "info", 4) != 0))
 	{
 		print_help();


### PR DESCRIPTION
This is taken from the Makefile used for bin2c in BlocksDS.

It lets you install the binary to the location specified in INSTALLDIR.

It lets you define a version string with VERSION_STRING. If not, it defaults to whatever it can get with "git describe".