### PR TITLE
Remove unused <malloc.h> header.

### DIFF
--- a/dldipatch.c
+++ b/dldipatch.c
@@ -7,7 +7,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>


### PR DESCRIPTION
This header does not exist on macOS, preventing builds there.